### PR TITLE
Friendlier installation instructions for users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ user units installed correctly, otherwise the on/off switch will not work.
 
 ### extensions.gnome.org
 
-The easiest way to install the extension will be from the Gnome extensions website.
+The easiest way to install the Syncthing Icon will be from the Gnome Extensions website.
 [See my listing there](https://extensions.gnome.org/extension/989/syncthing-icon/).
-You can install and activate the extension all at once by click the switch to
-ON, and next to the switch, you can click to wrench icon to configure the
+You can install and activate the extension all at once by clicking the switch to
+ON, and next to the switch, you can click the wrench icon to configure the
 extension, in case you need to change the port number for the Syncthing web
 client.
 
@@ -46,6 +46,9 @@ gnome-shell-extension-prefs &
 
 Or, if you have the Gnome Tweak Tool installed, you can launch that and go to
 the Extensions tab.
+
+You can also manage shell extensions from the Gnome Extensions website:
+https://extensions.gnome.org/local/
 
 Once you see the list of extensions, look for "Syncthing icon," and click to
 set the switch to ON.

--- a/README.md
+++ b/README.md
@@ -2,28 +2,35 @@
 
 This is a simple shell extension for Gnome 3.
 It features a small symbolic Syncthing icon that opens a menu with
-- an on/off switch for starting/stopping Syncthing by utilizing `systemctl --user`
+- an on/off switch for starting/stopping Syncthing
 - a button for opening the Web user interface (http://localhost:8384 or some other configurable URI)
 - a list of folders that are managed by Syncthing
 
+## Requirements
+This extension uses the **user service** management facilities of systemd. The
+[Syncthing documentation](http://docs.syncthing.net/users/autostart.html#how-to-use-the-user-instance)
+has information about how to set this up. Please make sure that you have the
+user units installed correctly, otherwise the on/off switch will not work.
+
 ## Installation
-To install, just run:
+
+The install script will make sure all the necessary files are copied to the
+correct place for you.
 ```sh
 ./install.sh
 ```
 
-Activate:
+After that, all you have to do is enable Syncthing Icon in your list of shell
+extensions. Gnome Shell comes with a simple GUI application that lists all the
+extensions that you have currently installed, but for some reason it does not
+normally show up when you search the application menu. You have to launch it
+from the terminal, or from the Run Commands dialog (`Alt-F2`). Enter this:
 ```sh
 gnome-shell-extension-prefs &
 ```
 
-## systemd
-This extension utilizes the **user** service management facilities of systemd.
-Please make sure that you have the user units installed correctly, otherwise the on/off switch will not work.
-You can check with
-```sh
-systemctl --user list-unit-files
-```
+Or, if you have the Gnome Tweak Tool installed, you can launch that and go to
+the Extensions tab.
 
-For further information, please see the
-[Syncthing documentation](http://docs.syncthing.net/users/autostart.html#how-to-use-the-user-instance).
+Once you see the list of extensions, look for "Syncthing icon," and click to
+set the switch to ON.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,27 @@ It features a small symbolic Syncthing icon that opens a menu with
 - a list of folders that are managed by Syncthing
 
 ## Requirements
+
 This extension uses the **user service** management facilities of systemd. The
 [Syncthing documentation](http://docs.syncthing.net/users/autostart.html#how-to-use-the-user-instance)
 has information about how to set this up. Please make sure that you have the
 user units installed correctly, otherwise the on/off switch will not work.
 
 ## Installation
+
+### extensions.gnome.org
+
+The easiest way to install the extension will be from the Gnome extensions website.
+[See my listing there](https://extensions.gnome.org/extension/989/syncthing-icon/).
+You can install and activate the extension all at once by click the switch to
+ON, and next to the switch, you can click to wrench icon to configure the
+extension, in case you need to change the port number for the Syncthing web
+client.
+
+If you have any trouble with this, see the Gnome Shell Extensions site's
+[FAQ page](https://extensions.gnome.org/about/).
+
+### installing manually
 
 The install script will make sure all the necessary files are copied to the
 correct place for you.


### PR DESCRIPTION
I thought the note about setting up systemd ought to come *before* the Installation section. With that done, mentioning the systemd requirement in the features list seemed redundant.

And then while I was at it, I expanded the Installation section a bit.