### PR TITLE
Updated metadata to Gnome 3.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.16", "3.18"],
+    "shell-version": ["3.16", "3.18", "3.20"],
     "uuid": "syncthingicon@jay.strict@posteo.de",
     "url": "https://github.com/jaystrictor/gnome-shell-extension-syncthing",
     "name": "Syncthing Icon",


### PR DESCRIPTION
Updated metadata.json to work with Gnome 3.20. The extensions works fine so far.