### PR TITLE
add an option to always use external browser

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -282,6 +282,8 @@ const SyncthingMenu = new Lang.Class({
     },
 
     _onSettingsChanged: function(settings, key) {
+        this.externalBrowser = Settings.get_boolean('external-browser');
+
         if (Settings.get_boolean('autoconfig')) {
             if (! this._configFileWatcher) {
                 this._onAutoConfigChanged(null);
@@ -335,7 +337,7 @@ const SyncthingMenu = new Lang.Class({
     },
 
     _onConfig: function(actor, event) {
-        if (this.baseURI.startsWith('http://')) {
+        if (!this.externalBrowser && this.baseURI.startsWith('http://')) {
             this._openWebView();
         } else {
             let launchContext = global.create_app_launch_context(event.get_time(), -1);

--- a/prefs.js
+++ b/prefs.js
@@ -68,6 +68,18 @@ const SyncthingIconPrefsWidget = new GObject.Class({
         this.attach(apiKeyEntry, 1, 2, 1, 1);
         this._settings.bind('api-key', apiKeyEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
 
+        let externalBrowserLabel = '<b>' + _("Always use external browser") + '</b>';
+        this.attach(new Gtk.Label({ label: externalBrowserLabel,
+                                    use_markup: true,
+                                    halign: Gtk.Align.END,
+                                    valign: Gtk.Align.BASELINE }),
+                    0, 3, 1, 1);
+
+        let externalBrowserSwitch = new Gtk.Switch({ halign: Gtk.Align.START,
+                                                     valign: Gtk.Align.BASELINE });
+        this.attach(externalBrowserSwitch, 1, 3, 2, 1);
+        this._settings.bind('external-browser', externalBrowserSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+
 
         autoSwitch.connect('notify::active', Lang.bind(this, this._onSwitch));
         this._onSwitch(autoSwitch);

--- a/schemas/org.gnome.shell.extensions.syncthing.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.syncthing.gschema.xml
@@ -16,5 +16,10 @@
       <summary>API Key</summary>
       <description>An API Key used to authenticate to Syncthing.</description>
     </key>
+    <key name="external-browser" type="b">
+      <default>false</default>
+      <summary>Always open the web interface in the external browser</summary>
+      <description>Always open the web interface in the external browser, never use the built-in webview.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
upon user's preference...
sometimes the internal WebView just annoying, can't change font scale...

another attempt to workaround https://github.com/jaystrictor/gnome-shell-extension-syncthing/issues/16