### PR TITLE
Remove "conditional catch" syntax

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -145,12 +145,16 @@ const FolderMenuItem = new Lang.Class({
         try {
             let query_info = file.query_info('standard::symbolic-icon', 0, null);
             return query_info.get_symbolic_icon();
-        } catch(e if e instanceof Gio.IOErrorEnum) {
-            // return a generic icon
-            if (!file.is_native())
-                return new Gio.ThemedIcon({ name: 'folder-remote-symbolic' });
-            else
-                return new Gio.ThemedIcon({ name: 'folder-symbolic' });
+        } catch(e) {
+            if (e instanceof Gio.IOErrorEnum) {
+              // return a generic icon
+              if (!file.is_native())
+                return new Gio.ThemedIcon({name: 'folder-remote-symbolic'});
+              else
+                return new Gio.ThemedIcon({name: 'folder-symbolic'});
+            } else {
+                throw e;
+            }
         }
     },
 


### PR DESCRIPTION
Because it's not supported in Gnome 3.30's JS engine anymore

For #36