### PR TITLE
Set "fill-opacity" for status icon

### DIFF
--- a/icons/syncthing-logo-symbolic.svg
+++ b/icons/syncthing-logo-symbolic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-9.061480784023479 -8.711829305257275 17.42365861051455 17.42365861051455" heigth="17.42365861051455" width="17.42365861051455">
-    <circle cx="0" cy="0" r="7" style="fill:none;stroke:#bebebe;stroke-width:1.5;display:inline"/>
+    <circle cx="0" cy="0" r="7" style="fill:none;fill-opacity:0;stroke:#bebebe;stroke-width:1.5;display:inline"/>
     <path d="M 1.75,1.05 m -1.8,0 a 1.8,1.8 0 1 1 3.6,0 a 1.8,1.8 0 1 1 -3.6,0" style="fill:#bebebe;fill-opacity:1;stroke:none;display:inline"/>
     <path d="M 6.062177826491071,-3.4999999999999996 m -1.8,0 a 1.8,1.8 0 1 1 3.6,0 a 1.8,1.8 0 1 1 -3.6,0" style="fill:#bebebe;fill-opacity:1;stroke:none;display:inline"/>
     <line x1="6.062177826491071" y1="-3.4999999999999996" x2="1.75" y2="1.05" style="fill:none;stroke:#bebebe;stroke-width:1.2;display:inline"/>


### PR DESCRIPTION
On my Gnome 3.30 the icon appeared like this:
![image](https://user-images.githubusercontent.com/360800/46574018-741e6e80-c99d-11e8-9c66-16bd83b56595.png)

With `fill-opacity:0`:
![image](https://user-images.githubusercontent.com/360800/46574064-27876300-c99e-11e8-8fe6-489bf98864da.png)
