### PR TITLE
Reading the config file of kozec flatpak version

### DIFF
--- a/src/filewatcher.js
+++ b/src/filewatcher.js
@@ -27,6 +27,7 @@ function probeDirectories() {
     const directories = [
         `${GLib.get_user_config_dir()}/syncthing`,
         `${GLib.get_home_dir()}/snap/syncthing/common/syncthing`,
+        `${GLib.get_home_dir()}/.var/app/me.kozec.syncthingtk/config/syncthing`,
     ];
     for (let dir of directories) {
         let configfile = Gio.File.new_for_path(`${dir}/config.xml`);


### PR DESCRIPTION
I've added path to flatpak version config file. Testes on Fedora 31 with kozec flatpak version from flathub.