### PR TITLE
metadata: declare compatibility with GNOME 42

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["40", "41"],
+    "shell-version": ["40", "41", "42"],
     "uuid": "syncthingicon@jay.strict@posteo.de",
     "url": "https://github.com/jaystrictor/gnome-shell-extension-syncthing",
     "name": "Syncthing Icon",


### PR DESCRIPTION
The extensions was showing as "Outdated", but Looking Glass showed no
errors. Just adding 42 to the list, reinstalling, and restarting
gnome-shell made it work for me.