### PR TITLE
Look for the Syncthing config file in new default location

### DIFF
--- a/src/filewatcher.js
+++ b/src/filewatcher.js
@@ -25,6 +25,7 @@ function myLog(msg) {
 
 function probeDirectories() {
     const directories = [
+        `${GLib.get_user_state_dir()}/syncthing`,
         `${GLib.get_user_config_dir()}/syncthing`,
         `${GLib.get_home_dir()}/snap/syncthing/common/syncthing`,
         `${GLib.get_home_dir()}/.var/app/me.kozec.syncthingtk/config/syncthing`,


### PR DESCRIPTION
Syncthing in version 1.27.0 changed the default UNIX location for its configuration and database directory to $XDG_STATE_HOME according to the XDG Base Directory Specification.  On the basis that these files are not really "configuration" as in user preferences, but they describe the state of the Syncthing setup for a specific device. Especially they cannot be shared between devices.

Thus the extension would fail to connect on newer installations because it cannot find the config file and therefore is missing the API key.  Add the new default path to the list of directories tried.