### PR TITLE
Port to GNOME 46

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -49,7 +49,7 @@ const SyncthingMenu = new GObject.registerClass(
 
         _initButton() {
             let box = new St.BoxLayout();
-            this.add_actor(box);
+            this.add_child(box);
 
             this._syncthingIcon = new St.Icon({ gicon: this._getSyncthingIcon(),
                 style_class: "system-status-icon" });

--- a/src/filewatcher.js
+++ b/src/filewatcher.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const Lang = imports.lang;
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import * as Saxes from './saxes.js';
 
 function getCurrentDir() {
     let stack = (new Error()).stack;
@@ -17,13 +17,12 @@ function getCurrentDir() {
     return file.get_parent();
 }
 imports.searchPath.unshift(getCurrentDir().get_path());
-const Saxes = imports.saxes;
 
 function myLog(msg) {
     log(`[syncthingicon] ${msg}`);
 }
 
-function probeDirectories() {
+export function probeDirectories() {
     const directories = [
         `${GLib.get_user_config_dir()}/syncthing`,
         `${GLib.get_home_dir()}/snap/syncthing/common/syncthing`,
@@ -46,7 +45,7 @@ function probeDirectories() {
     return null;
 }
 
-const ConfigParser = class {
+export const ConfigParser = class {
     constructor(file) {
         this.file = file;
         this.state = "root";
@@ -132,7 +131,7 @@ const ConfigParser = class {
 const WARMUP_TIME = 1;
 const COOLDOWN_TIME = 10;
 
-var ConfigFileWatcher = class {
+export const ConfigFileWatcher = class {
     /* File Watcher with 4 internal states:
        ready -> warmup -> running -> cooldown
          ^                              |

--- a/src/folders.js
+++ b/src/folders.js
@@ -1,24 +1,22 @@
 "use strict";
 
-const Clutter = imports.gi.Clutter;
-const Gio = imports.gi.Gio;
-const GObject = imports.gi.GObject;
-const St = imports.gi.St;
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
 
 
-const Main = imports.ui.main;
-const PopupMenu = imports.ui.popupMenu;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 function myLog(msg) {
     log(`[syncthingicon] ${msg}`);
 }
 
-var FolderList = class extends PopupMenu.PopupMenuSection {
-    constructor(menu, api) {
+export const FolderList = class extends PopupMenu.PopupMenuSection {
+    constructor(menu, api, ext) {
         super();
+        this._ext = ext;
         this._menu = menu;
         this._api = api;
         this.folder_ids = [];
@@ -32,7 +30,7 @@ var FolderList = class extends PopupMenu.PopupMenuSection {
         let id = folder.id;
         let position = this._sortedIndex(id);
         this.folder_ids.splice(position, 0, id);
-        let menuitem = new FolderMenuItem(folder);
+        let menuitem = new FolderMenuItem(folder, this._ext);
         this.addMenuItem(menuitem, position);
         this.folders.set(id, menuitem);
         this._menu.notifyListChanged();
@@ -74,16 +72,9 @@ var FolderList = class extends PopupMenu.PopupMenuSection {
 }
 
 
-function getFolderStatusIcon(iconName) {
-    let path = Me.dir.get_path() + "/icons/hicolor/scalable/status/" + iconName + ".svg";
-    let gicon = Gio.icon_new_for_string(path);
-    return gicon;
-}
-
-
 var FolderMenuItem = GObject.registerClass(
 class FolderMenuItem extends PopupMenu.PopupBaseMenuItem {
-    _init(folder) {
+    _init(folder, ext) {
         super._init();
         this.folder = folder;
         this._icon = new St.Icon({ gicon: this._getIcon(folder.path),
@@ -128,6 +119,12 @@ class FolderMenuItem extends PopupMenu.PopupBaseMenuItem {
         }
     }
 
+    _getFolderStatusIcon(iconName) {
+        let path = this._ext.dir.get_path() + "/icons/hicolor/scalable/status/" + iconName + ".svg";
+        let gicon = Gio.icon_new_for_string(path);
+        return gicon;
+    }
+
     activate(event) {
         let path = this.folder.path;
         if (! path)
@@ -166,36 +163,36 @@ class FolderMenuItem extends PopupMenu.PopupBaseMenuItem {
             case "scan-waiting":
                 this._label_state.set_text("");
                 this._statusIcon.visible = true;
-                this._statusIcon.gicon = getFolderStatusIcon("database");
+                this._statusIcon.gicon = _getFolderStatusIcon("database");
                 break;
             case "sync-waiting":
             case "sync-preparing":
             case "syncing":
                 this._label_state.set_text("%d\u2009%%".format(pct));
                 this._statusIcon.visible = true;
-                this._statusIcon.gicon = getFolderStatusIcon("cloud-down");
+                this._statusIcon.gicon = _getFolderStatusIcon("cloud-down");
                 break;
             case "cleaning":
             case "clean-waiting":
                 this._label_state.set_text("");
                 this._statusIcon.visible = true;
-                this._statusIcon.gicon = getFolderStatusIcon("database");
+                this._statusIcon.gicon = _getFolderStatusIcon("database");
                 break;
             case "error":
                 this._label_state.set_text("");
                 this._statusIcon.visible = true;
-                this._statusIcon.gicon = getFolderStatusIcon("exclamation-triangle");
+                this._statusIcon.gicon = _getFolderStatusIcon("exclamation-triangle");
                 break;
             case "unknown":
                 this._label_state.set_text("");
                 this._statusIcon.visible = true;
-                this._statusIcon.gicon = getFolderStatusIcon("question");
+                this._statusIcon.gicon = _getFolderStatusIcon("question");
                 break;
             default:
                 myLog(`unknown syncthing folder state "${state}"`);
                 this._label_state.set_text("");
                 this._statusIcon.visible = true;
-                this._statusIcon.gicon = getFolderStatusIcon("question");
+                this._statusIcon.gicon = _getFolderStatusIcon("question");
         }
     }
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["45"],
+    "shell-version": ["46"],
     "uuid": "syncthingicon@jay.strict@posteo.de",
     "url": "https://github.com/jaystrictor/gnome-shell-extension-syncthing",
     "name": "Syncthing Icon",

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["43"],
+    "shell-version": ["45"],
     "uuid": "syncthingicon@jay.strict@posteo.de",
     "url": "https://github.com/jaystrictor/gnome-shell-extension-syncthing",
     "name": "Syncthing Icon",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,21 +1,17 @@
 "use strict";
 
-const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
-const GObject = imports.gi.GObject;
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
+import GObject from 'gi://GObject';
+import Adw from 'gi://Adw';
 
-const GETTEXT_DOMAIN = "gnome-shell-extension-syncthing";
-const Gettext = imports.gettext.domain(GETTEXT_DOMAIN);
-const _ = Gettext.gettext;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 const SyncthingIconPrefsWidget = GObject.registerClass(
 class SyncthingIconPrefsWidget extends Gtk.Grid {
-    _init(params) {
-        super._init(params);
-        this._settings = ExtensionUtils.getSettings();
+    _init(settings) {
+        super._init();
+        this._settings = settings;
 
         this.margin = 18;
         this.row_spacing = this.column_spacing = 12;
@@ -98,12 +94,15 @@ class SyncthingIconPrefsWidget extends Gtk.Grid {
     }
 });
 
-function init(metadata) {
-    ExtensionUtils.initTranslations(GETTEXT_DOMAIN);
-}
 
-function buildPrefsWidget() {
-    let widget = new SyncthingIconPrefsWidget();
+export default class SystemMonitorExtensionPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const page = new Adw.PreferencesPage();
+        const group = new Adw.PreferencesGroup();
+        const widget = new SyncthingIconPrefsWidget(this.getSettings());
 
-    return widget;
+        group.add(widget);
+        page.add(group);
+        window.add(page);
+    }
 }

--- a/src/saxes.js
+++ b/src/saxes.js
@@ -439,7 +439,7 @@ ${XMLNS_NAMESPACE}.`);
  * like.
  */
 
-var SaxesParser = class SaxesParser {
+export const SaxesParser = class SaxesParser {
   /**
    * @param {SaxesOptions} opt The parser options.
    */

--- a/src/syncthing_api.js
+++ b/src/syncthing_api.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const Gio = imports.gi.Gio;
-const GObject = imports.gi.GObject;
-const GLib = imports.gi.GLib;
-const Soup = imports.gi.Soup;
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import GLib from 'gi://GLib';
+import Soup from 'gi://Soup';
 
 const decoder = new TextDecoder('utf-8');
 
@@ -129,7 +129,7 @@ var Folder = GObject.registerClass({
 });
 
 
-var SyncthingSession = GObject.registerClass({
+export const SyncthingSession = GObject.registerClass({
     Signals: {
         "connection-state-changed": {
             param_types: [ GObject.TYPE_STRING ],

--- a/src/systemd.js
+++ b/src/systemd.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const Gio = imports.gi.Gio;
-const GObject = imports.gi.GObject;
-const GLib = imports.gi.GLib;
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import GLib from 'gi://GLib';
 
 
 function myLog(msg) {
@@ -10,7 +10,7 @@ function myLog(msg) {
 }
 
 
-var Control = GObject.registerClass({
+export const Control = GObject.registerClass({
     Signals: {
         "state-changed": {
             // "systemd-not-available", "unit-not-loaded", "active", or "inactive"

--- a/src/webviewer.js
+++ b/src/webviewer.js
@@ -1,18 +1,17 @@
 "use strict";
 
-imports.gi.versions.Gtk = '3.0';
-imports.gi.versions.WebKit2 = '4.0';
-const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
-const GObject = imports.gi.GObject;
-const WebKit = imports.gi.WebKit2;
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk?version=3.0';
+import GObject from 'gi://GObject';
+import WebKit from 'gi://WebKit2?version=4.0';
+import * as Filewatcher from './filewatcher.js';
 
 function getCurrentDir() {
     let stack = (new Error()).stack;
     let stackLine = stack.split("\n")[1];
     if (!stackLine)
         throw new Error("Could not find current file.");
-    let match = new RegExp("@(.+):\\d+").exec(stackLine);
+    let match = new RegExp("@file://(.+):\\d+").exec(stackLine);
     if (!match)
         throw new Error("Could not find current file.");
     let path = match[1];
@@ -20,7 +19,6 @@ function getCurrentDir() {
     return file.get_parent();
 }
 imports.searchPath.unshift(getCurrentDir().get_path());
-const Filewatcher = imports.filewatcher;
 
 function myLog(msg) {
     log(`[syncthingicon-webview] ${msg}`);


### PR DESCRIPTION
Replace deprecated call to add_actor() with the recommended add_child().  Declare compatibility with version 46.

This is based on #75 and includes those changes.